### PR TITLE
add support for default-values in constructor parameters

### DIFF
--- a/src/AutoWireFactory.php
+++ b/src/AutoWireFactory.php
@@ -43,6 +43,7 @@ class AutoWireFactory implements FactoryInterface, AbstractFactoryInterface
         if (file_exists($cacheFile)) {
             $contents = @file_get_contents($cacheFile);
             if ($contents !== false) {
+                /** @noinspection UnserializeExploitsInspection */
                 $data = @unserialize($contents);
                 if (is_array($data)) {
                     /** @var array<class-string, array<ResolverInterface>> $data */
@@ -80,7 +81,7 @@ class AutoWireFactory implements FactoryInterface, AbstractFactoryInterface
             throw new FailedReflectionException($requestedName, $e);
         }
 
-        $values = array_map(fn (ResolverInterface $resolver) => $resolver->resolve($container), $resolvers);
+        $values = array_map(static fn (ResolverInterface $resolver) => $resolver->resolve($container), $resolvers);
         return new $requestedName(...$values);
     }
 

--- a/src/Resolver/DefaultResolver.php
+++ b/src/Resolver/DefaultResolver.php
@@ -28,7 +28,7 @@ class DefaultResolver implements ResolverInterface, ParameterAwareInterface
         if ($type instanceof ReflectionNamedType) {
             $this->aliases[] = "{$type->getName()} \${$parameter->getName()}";
             if (!$type->isBuiltin()) {
-                $this->aliases[] = "{$type->getName()}";
+                $this->aliases[] = $type->getName();
             }
         }
         $this->aliases[] = "\${$parameter->getName()}";

--- a/src/Resolver/DefaultValueResolver.php
+++ b/src/Resolver/DefaultValueResolver.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BluePsyduck\LaminasAutoWireFactory\Resolver;
+
+use Psr\Container\ContainerInterface;
+use ReflectionException;
+use ReflectionParameter;
+
+/**
+ * @author richard.weinhold
+ * @since 12.09.2023
+ */
+class DefaultValueResolver implements ResolverInterface, ParameterAwareInterface
+{
+    private bool $hasDefaultValue;
+    private mixed $defaultValue;
+
+    /**
+     * @inheritDoc
+     * @throws ReflectionException
+     */
+    public function setParameter(ReflectionParameter $parameter): void
+    {
+        $this->hasDefaultValue = $parameter->isDefaultValueAvailable();
+        $this->defaultValue = $parameter->getDefaultValue();
+    }
+
+    public function resolve(ContainerInterface $container): mixed
+    {
+        return $this->defaultValue;
+    }
+
+    public function canResolve(ContainerInterface $container): bool
+    {
+        return $this->hasDefaultValue;
+    }
+
+    /**
+     * @return array{h:bool,v:mixed}
+     */
+    public function __serialize(): array
+    {
+        return ['h' => $this->hasDefaultValue, 'v' => $this->defaultValue];
+    }
+
+    /**
+     * @param array{h?:bool,v?:mixed} $data
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->hasDefaultValue = $data['h'] ?? false;
+        $this->defaultValue = $data['v'] ?? null;
+    }
+}

--- a/src/Resolver/ResolverFactory.php
+++ b/src/Resolver/ResolverFactory.php
@@ -38,14 +38,17 @@ class ResolverFactory
      * Creates the resolver for the specified parameter.
      * @param ReflectionParameter $parameter
      * @return ResolverInterface
+     * @throws ReflectionException
      */
     public function createResolverForParameter(ReflectionParameter $parameter): ResolverInterface
     {
         $attributes = $parameter->getAttributes(ResolverAttribute::class, ReflectionAttribute::IS_INSTANCEOF);
         if (count($attributes) > 0) {
-            /* @var ResolverAttribute $attribute*/
+            /* @var ResolverAttribute $attribute */
             $attribute = $attributes[0]->newInstance();
             $resolver = $attribute->createResolver();
+        } elseif ($parameter->isDefaultValueAvailable()) {
+            $resolver = new DefaultValueResolver();
         } else {
             $resolver = new DefaultResolver();
         }

--- a/test/asset/ClassWithDefaultValuesConstructor.php
+++ b/test/asset/ClassWithDefaultValuesConstructor.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BluePsyduckTestAsset\LaminasAutoWireFactory;
+
+/**
+ * @author richard.weinhold
+ * @since 12.09.2023
+ */
+class ClassWithDefaultValuesConstructor
+{
+    /** @param string[] $defaultArray */
+    public function __construct(
+        public ClassWithoutConstructor $foo,
+        public string $defaultString = 'default-string',
+        public array $defaultArray = ['default-array', '1234'],
+    ) {
+    }
+}

--- a/test/integration/AutoWireFactoryIntegrationTest.php
+++ b/test/integration/AutoWireFactoryIntegrationTest.php
@@ -7,6 +7,7 @@ namespace BluePsyduckIntegrationTest\LaminasAutoWireFactory;
 use BluePsyduck\LaminasAutoWireFactory\AutoWireFactory;
 use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithAttributes;
 use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithClassTypeHintConstructor;
+use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithDefaultValuesConstructor;
 use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithoutConstructor;
 use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithParameterlessConstructor;
 use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithScalarTypeHintConstructor;
@@ -37,6 +38,7 @@ class AutoWireFactoryIntegrationTest extends TestCase
             [ClassWithClassTypeHintConstructor::class],
             [ClassWithScalarTypeHintConstructor::class],
             [ClassWithAttributes::class],
+            [ClassWithDefaultValuesConstructor::class],
         ];
     }
 
@@ -64,6 +66,7 @@ class AutoWireFactoryIntegrationTest extends TestCase
                 ClassWithParameterlessConstructor::class => AutoWireFactory::class,
                 ClassWithScalarTypeHintConstructor::class => AutoWireFactory::class,
                 ClassWithAttributes::class => AutoWireFactory::class,
+                ClassWithDefaultValuesConstructor::class => AutoWireFactory::class,
             ],
         ]);
 

--- a/test/src/Resolver/DefaultValueResolverTest.php
+++ b/test/src/Resolver/DefaultValueResolverTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BluePsyduckTest\LaminasAutoWireFactory\Resolver;
+
+use BluePsyduck\LaminasAutoWireFactory\Resolver\DefaultValueResolver;
+use BluePsyduck\TestHelper\ReflectionTrait;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use ReflectionException;
+use ReflectionParameter;
+
+/**
+ * The PHPUnit test of the DefaultValueResolver class.
+ *
+ * @author ricwein <git@ricwein.com>
+ * @license http://opensource.org/licenses/GPL-3.0 GPL v3
+ *
+ * @covers \BluePsyduck\LaminasAutoWireFactory\Resolver\DefaultValueResolver
+ */
+class DefaultValueResolverTest extends TestCase
+{
+    use ReflectionTrait;
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testSetParameter(): void
+    {
+        $expectedValue = 'default-value';
+
+        $parameter = $this->createMock(ReflectionParameter::class);
+        $parameter->expects($this->any())
+            ->method('isDefaultValueAvailable')
+            ->willReturn(true);
+        $parameter->expects($this->any())
+            ->method('getDefaultValue')
+            ->willReturn($expectedValue);
+
+        $instance = new DefaultValueResolver();
+        $instance->setParameter($parameter);
+
+        $this->assertEquals($expectedValue, $this->extractProperty($instance, 'defaultValue'));
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws ReflectionException
+     */
+    public function testResolve(): void
+    {
+        $expectedValue = 'default-value';
+
+        $container = $this->createMock(ContainerInterface::class);
+
+        $instance = new DefaultValueResolver();
+        $this->injectProperty($instance, 'defaultValue', $expectedValue);
+        $this->injectProperty($instance, 'hasDefaultValue', true);
+
+        $result = $instance->resolve($container);
+        $this->assertSame($expectedValue, $result);
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testCanResolve(): void
+    {
+        $expectedValue = 'default-value';
+        $container = $this->createMock(ContainerInterface::class);
+
+        $instance = new DefaultValueResolver();
+        $this->injectProperty($instance, 'defaultValue', $expectedValue);
+        $this->injectProperty($instance, 'hasDefaultValue', true);
+
+        $result = $instance->canResolve($container);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testCanResolveReturningFalse(): void
+    {
+        $expectedValue = 'default-value';
+        $container = $this->createMock(ContainerInterface::class);
+
+        $instance = new DefaultValueResolver();
+        $this->injectProperty($instance, 'defaultValue', $expectedValue);
+        $this->injectProperty($instance, 'hasDefaultValue', false);
+
+        $result = $instance->canResolve($container);
+        $this->assertFalse($result);
+    }
+
+    public function testSerialize(): void
+    {
+        $expectedValue = 'default-value';
+
+        $parameter = $this->createMock(ReflectionParameter::class);
+        $parameter->expects($this->any())
+            ->method('isDefaultValueAvailable')
+            ->willReturn(true);
+        $parameter->expects($this->any())
+            ->method('getDefaultValue')
+            ->willReturn($expectedValue);
+
+        $instance = new DefaultValueResolver();
+        $instance->setParameter($parameter);
+
+        $result = unserialize(serialize($instance));
+        $this->assertEquals($instance, $result);
+    }
+}


### PR DESCRIPTION
## Description
The current implementation has no support for parameters with default values, but always tries to resolve all parameters instead. This PR changes this behaviour, implementing a new `DefaultValueResolver`. Since (prior to this PR) the AutoWireFactory will already fail to resolve these parameters, this should **NOT** be a breaking change.

### Result
Resolver-Priority will be as following:
 1. If `ResolverAttribute`s are set, use them
 2. If no Attributes are set, but a default value is present, use the DefaultValueResolver with this default value.
 3. If also not default value is set, use the `DefaultResolver`.

## This PR does:
- add new DefaultValueResolver which is automatically injected for parameters without explicit attributes, but with set default value
- parameters with default-values will no longer be resolved with the DefaultResolver, but directly with the DefaultValueResolver instead