### PR TITLE
upgrades to laminas-servicemanager 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "laminas/laminas-servicemanager": "^3.0"
+        "php": "^8.1",
+        "laminas/laminas-servicemanager": "^4.0"
     },
     "require-dev": {
         "bluepsyduck/test-helper": "^2.0",

--- a/src/AutoWireFactory.php
+++ b/src/AutoWireFactory.php
@@ -7,10 +7,10 @@ namespace BluePsyduck\LaminasAutoWireFactory;
 use BluePsyduck\LaminasAutoWireFactory\Exception\FailedReflectionException;
 use BluePsyduck\LaminasAutoWireFactory\Resolver\ResolverFactory;
 use BluePsyduck\LaminasAutoWireFactory\Resolver\ResolverInterface;
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
 use ReflectionException;
 
 /**
@@ -69,7 +69,7 @@ class AutoWireFactory implements FactoryInterface, AbstractFactoryInterface
      * @return object
      * @throws ContainerExceptionInterface
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): object
+    public function __invoke(ContainerInterface $container, string $requestedName, ?array $options = null): object
     {
         if (!class_exists($requestedName)) {
             throw new FailedReflectionException($requestedName);
@@ -91,7 +91,7 @@ class AutoWireFactory implements FactoryInterface, AbstractFactoryInterface
      * @param string $requestedName
      * @return bool
      */
-    public function canCreate(ContainerInterface $container, $requestedName): bool
+    public function canCreate(ContainerInterface $container, string $requestedName): bool
     {
         if (!class_exists($requestedName)) {
             return false;

--- a/src/Factory/AbstractConfigResolverFactory.php
+++ b/src/Factory/AbstractConfigResolverFactory.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace BluePsyduck\LaminasAutoWireFactory\Factory;
 
 use BluePsyduck\LaminasAutoWireFactory\Resolver\ResolverInterface;
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * The abstract class for factories using a config resolver.

--- a/test/integration/AliasArrayInjectorFactoryTest.php
+++ b/test/integration/AliasArrayInjectorFactoryTest.php
@@ -8,7 +8,6 @@ use BluePsyduck\LaminasAutoWireFactory\AutoWireUtils;
 use BluePsyduck\LaminasAutoWireFactory\Exception\MissingConfigException;
 use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithoutConstructor;
 use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithParameterlessConstructor;
-use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
@@ -44,7 +43,7 @@ class AliasArrayInjectorFactoryTest extends TestCase
 
         $container = new ServiceManager();
         $container->setService('config', $config);
-        (new Config($dependencies))->configureServiceManager($container);
+        $container->configure($dependencies);
 
         return $container;
     }

--- a/test/integration/AutoWireFactoryIntegrationTest.php
+++ b/test/integration/AutoWireFactoryIntegrationTest.php
@@ -11,7 +11,6 @@ use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithDefaultValuesConstructo
 use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithoutConstructor;
 use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithParameterlessConstructor;
 use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithScalarTypeHintConstructor;
-use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
@@ -45,7 +44,7 @@ class AutoWireFactoryIntegrationTest extends TestCase
     private function createContainerWithExplicitFactories(): ContainerInterface
     {
         // @phpstan-ignore-next-line
-        $config = new Config([
+        $config = [
             'services' => [
                 'string $property' => 'abc',
                 'array $instances' => ['def', 'ghi'],
@@ -68,12 +67,9 @@ class AutoWireFactoryIntegrationTest extends TestCase
                 ClassWithAttributes::class => AutoWireFactory::class,
                 ClassWithDefaultValuesConstructor::class => AutoWireFactory::class,
             ],
-        ]);
+        ];
 
-        $container = new ServiceManager();
-        $config->configureServiceManager($container);
-
-        return $container;
+        return new ServiceManager($config);
     }
 
     /**
@@ -92,7 +88,7 @@ class AutoWireFactoryIntegrationTest extends TestCase
     protected function createContainerWithAbstractFactory(): ContainerInterface
     {
         // @phpstan-ignore-next-line
-        $config = new Config([
+        $config = [
             'services' => [
                 'string $property' => 'abc',
                 'array $instances' => ['def', 'ghi'],
@@ -110,12 +106,9 @@ class AutoWireFactoryIntegrationTest extends TestCase
             'abstract_factories' => [
                 AutoWireFactory::class,
             ],
-        ]);
+        ];
 
-        $container = new ServiceManager();
-        $config->configureServiceManager($container);
-
-        return $container;
+        return new ServiceManager($config);
     }
 
     /**

--- a/test/integration/ConfigAggregatorIntegrationTest.php
+++ b/test/integration/ConfigAggregatorIntegrationTest.php
@@ -10,7 +10,6 @@ use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithoutConstructor;
 use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithParameterlessConstructor;
 use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithScalarTypeHintConstructor;
 use Laminas\ConfigAggregator\ConfigAggregator;
-use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
 
@@ -59,7 +58,7 @@ class ConfigAggregatorIntegrationTest extends TestCase
         $result = new ServiceManager();
 
         // @phpstan-ignore-next-line
-        (new Config($config['dependencies'] ?? []))->configureServiceManager($result);
+        $result->configure($config['dependencies'] ?? []);
         $result->setService('config', $config);
 
         return $result;

--- a/test/src/AutoWireFactoryTest.php
+++ b/test/src/AutoWireFactoryTest.php
@@ -14,11 +14,11 @@ use BluePsyduck\TestHelper\ReflectionTrait;
 use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithClassTypeHintConstructor;
 use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithoutConstructor;
 use BluePsyduckTestAsset\LaminasAutoWireFactory\ClassWithParameterlessConstructor;
-use Interop\Container\ContainerInterface;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
 use ReflectionException;
 
 /**

--- a/test/src/Factory/AbstractConfigResolverFactoryTest.php
+++ b/test/src/Factory/AbstractConfigResolverFactoryTest.php
@@ -8,9 +8,9 @@ use BluePsyduck\LaminasAutoWireFactory\Factory\AbstractConfigResolverFactory;
 use BluePsyduck\LaminasAutoWireFactory\Factory\AliasArrayInjectorFactory;
 use BluePsyduck\LaminasAutoWireFactory\Factory\ConfigReaderFactory;
 use BluePsyduck\LaminasAutoWireFactory\Resolver\ResolverInterface;
-use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
 use stdClass;
 
 /**


### PR DESCRIPTION
This PR adds support for the new `laminas-servermanager ^4.0` ([Packagist](https://packagist.org/packages/laminas/laminas-servicemanager#4.0.0)). Since it's a major upgrade with [breaking changes](https://github.com/laminas/laminas-servicemanager/releases/tag/4.0.0), this PR should also be viewed as a new major version. I suggest a release as version `3.0.0` 😃.

The Upgrade itself was pretty straight forward.

Comments from commit:

- adds support for laminas-servicemanager 4.0
- since the new service-manager itself is not backwards compatible, support for laminas-servicemanager 3.0 is dropped
- bump mininmal php version to 8.1 to adopt the same change in the laminas-servermanager lib

Greetings, ricwein